### PR TITLE
Allow to run individual unit tests

### DIFF
--- a/.github/scripts/bootstrap_openblas.bat
+++ b/.github/scripts/bootstrap_openblas.bat
@@ -1,0 +1,2 @@
+del %GITHUB_WORKSPACE%\pytorch-unit-tests\openblas\build /s /q /f
+del %GITHUB_WORKSPACE%\pytorch-unit-tests\openblas\install /s /q /f

--- a/.github/scripts/bootstrap_pytorch.bat
+++ b/.github/scripts/bootstrap_pytorch.bat
@@ -1,6 +1,7 @@
-@echo off
+pip uninstall torch -y
+pip uninstall pytorch -y
 
-call %GITHUB_WORKSPACE%\pytorch-unit-tests\workflow\.github\scripts\cleanup_pytorch.bat
+del %GITHUB_WORKSPACE%\pytorch-unit-tests\pytorch\install\* /s /q /f
 
 python -m pip install --upgrade pip
 python -m pip install -r requirements.txt

--- a/.github/scripts/bootstrap_tests.bat
+++ b/.github/scripts/bootstrap_tests.bat
@@ -1,3 +1,2 @@
-@echo off
-
-python -m pip install pytest
+python -m pip install --upgrade pip
+python -m pip install pytest pytest-shard pytest-rerunfailures pytest-flakefinder pytest-pytorch hypothesis numpy

--- a/.github/scripts/build_openblas_clang.bat
+++ b/.github/scripts/build_openblas_clang.bat
@@ -1,5 +1,3 @@
-@echo off
-
 set "vswhere=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
 set visualstudio=
 for /f "delims=" %%v in ('"%vswhere%" -latest -property installationPath') do set "visualstudio=%%v"
@@ -8,8 +6,8 @@ if "%visualstudio%" == "" (
   goto :eof
 )
 
-mkdir build
-cd build
+mkdir %GITHUB_WORKSPACE%\pytorch-unit-tests\openblas\build
+cd %GITHUB_WORKSPACE%\pytorch-unit-tests\openblas\build
 
 path=%path%;%visualstudio%\VC\Tools\Llvm\ARM64\bin
 

--- a/.github/scripts/build_openblas_msvc.bat
+++ b/.github/scripts/build_openblas_msvc.bat
@@ -1,5 +1,3 @@
-@echo off
-
 set "vswhere=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
 set visualstudio=
 for /f "delims=" %%v in ('"%vswhere%" -latest -property installationPath') do set "visualstudio=%%v"
@@ -8,11 +6,10 @@ if "%visualstudio%" == "" (
   goto :eof
 )
 
-
 call "%visualstudio%\VC\Auxiliary\Build\vcvarsall.bat" arm64
 
-mkdir build
-cd build
+mkdir %GITHUB_WORKSPACE%\pytorch-unit-tests\openblas\build
+cd %GITHUB_WORKSPACE%\pytorch-unit-tests\openblas\build
 
 cmake .. -G Ninja -DBUILD_TESTING=0
 cmake --build . --config Release

--- a/.github/scripts/build_pytorch.bat
+++ b/.github/scripts/build_pytorch.bat
@@ -1,5 +1,3 @@
-@echo off
-
 set "vswhere=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
 set visualstudio=
 for /f "delims=" %%v in ('"%vswhere%" -latest -property installationPath') do set "visualstudio=%%v"
@@ -10,9 +8,8 @@ if "%visualstudio%" == "" (
 
 call "%visualstudio%\VC\Auxiliary\Build\vcvarsall.bat" arm64
 
-if "%1" == "true" (
-  set BLAS=OpenBLAS
-  set OpenBLAS_HOME=%GITHUB_WORKSPACE%\pytorch-unit-tests\openblas\install
-)
+set BLAS=OpenBLAS
+set OpenBLAS_HOME=%GITHUB_WORKSPACE%\pytorch-unit-tests\openblas\install
 
-python setup.py install --cmake
+python setup.py install --cmake --home=%GITHUB_WORKSPACE%\pytorch-unit-tests\pytorch\install  
+python setup.py install

--- a/.github/scripts/cleanup_pytorch.bat
+++ b/.github/scripts/cleanup_pytorch.bat
@@ -1,4 +1,0 @@
-@echo off
-
-pip uninstall torch -y
-pip uninstall pytorch -y

--- a/.github/scripts/test.bat
+++ b/.github/scripts/test.bat
@@ -1,0 +1,13 @@
+del %GITHUB_WORKSPACE%\pytorch-unit-tests\pytorch\test\test-reports\* /s /q /f
+
+set CI=true
+
+@echo Started: %date% %time%
+
+if "%1%2"=="" (
+    call %GITHUB_WORKSPACE%\pytorch-unit-tests\workflow\.github\scripts\test_core.bat
+) else (
+    call %GITHUB_WORKSPACE%\pytorch-unit-tests\workflow\.github\scripts\test_individual.bat %1 %2 %3
+)
+
+@echo Completed: %date% %time%

--- a/.github/scripts/test_core.bat
+++ b/.github/scripts/test_core.bat
@@ -1,3 +1,1 @@
-@echo off
-
 python run_test.py --core --verbose --save-xml --keep-going

--- a/.github/scripts/test_individual.bat
+++ b/.github/scripts/test_individual.bat
@@ -1,0 +1,5 @@
+if "%3"=="" (
+    python run_test.py -i %1 --verbose --save-xml --keep-going --runs %2
+) else (
+    python run_test.py -i %1 --verbose --save-xml --keep-going --runs %2 --filter "%3" 
+)

--- a/.github/scripts/wipe_pytorch_cache.bat
+++ b/.github/scripts/wipe_pytorch_cache.bat
@@ -1,3 +1,1 @@
-@echo off
-
-del build\* /s /q /f
+del %GITHUB_WORKSPACE%\pytorch-unit-tests\pytorch\build\* /s /q /f

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -13,16 +13,6 @@ on:
         required: true
         default: "develop"
         type: string
-      pytorch_repository:
-        description: "PyTorch repository"
-        required: true
-        default: "Blackhex/pytorch"
-        type: string
-      pytorch_branch:
-        description: "PyTorch branch"
-        required: true
-        default: "run-tests"
-        type: string
       build_openblas_msvc:
         description: "Build OpenBLAS with MSVC"
         required: false
@@ -38,21 +28,26 @@ on:
         required: false
         default: false
         type: boolean
-      build_pytorch_openblas:
-        description: "Build PyTorch with OpenBLAS"
+      run_tests:
+        description: "Run tests"
         required: false
         default: false
         type: boolean
-      run_core_tests:
-        description: "Run core unit tests"
+      run_tests_suite:
+        description: "Test suite to run"
         required: false
-        default: false
-        type: boolean
-      wipe_cache:
-          description: "Completely wipe build cache"
-          required: false
-          default: false
-          type: boolean
+        default: ""
+        type: string
+      run_tests_filter:
+        description: "Test filter to run"
+        required: false
+        default: ""
+        type: string
+      run_tests_runs:
+        description: "Test runs to execute"
+        required: false
+        default: 1
+        type: number
 defaults:
   run:
     shell: cmd
@@ -77,18 +72,26 @@ jobs:
           submodules: recursive
           clean: false
       - name: Git checkout PyTorch
-        if: ${{ inputs.build_pytorch }}
+        if: ${{ inputs.build_pytorch || inputs.run_tests }}
         uses: actions/checkout@v3
         with:
-          repository: ${{ inputs.pytorch_repository }}
-          ref: ${{ inputs.pytorch_branch }}
+          repository: "Blackhex/pytorch"
+          ref: "run-tests"
           path: pytorch-unit-tests/pytorch
           submodules: recursive
           clean: false
-      - name: Wipe build cache
-        if: ${{ inputs.wipe_cache }}
+      - name: Bootstrap OpenBLAS build
+        if: ${{ inputs.build_openblas_msvc || inputs.build_openblas_clang }}
+        working-directory: pytorch-unit-tests/openblas
+        run: ${{ github.workspace }}/pytorch-unit-tests/workflow/.github/scripts/bootstrap_openblas.bat
+      - name: Bootstrap PyTorch build
+        if: ${{ inputs.build_pytorch }}
         working-directory: pytorch-unit-tests/pytorch
-        run: ${{ github.workspace }}/pytorch-unit-tests/workflow/.github/scripts/wipe_pytorch_cache.bat
+        run: ${{ github.workspace }}/pytorch-unit-tests/workflow/.github/scripts/bootstrap_pytorch.bat
+      - name: Bootstrap PyTorch tests
+        if: ${{ inputs.run_tests }}
+        working-directory: pytorch-unit-tests/pytorch
+        run: ${{ github.workspace }}/pytorch-unit-tests/workflow/.github/scripts/bootstrap_tests.bat
       - name: Build OpenBLAS with MSVC
         if: ${{ inputs.build_openblas_msvc }}
         working-directory: pytorch-unit-tests/openblas
@@ -97,23 +100,32 @@ jobs:
         if: ${{ inputs.build_openblas_clang }}
         working-directory: pytorch-unit-tests/openblas
         run: ${{ github.workspace }}/pytorch-unit-tests/workflow/.github/scripts/build_openblas_clang.bat
-      - name: Bootstrap PyTorch build
-        if: ${{ inputs.build_pytorch }}
-        working-directory: pytorch-unit-tests/pytorch
-        run: ${{ github.workspace }}/pytorch-unit-tests/workflow/.github/scripts/bootstrap_pytorch.bat
-      - name: Bootstrap PyTorch tests
-        if: ${{ inputs.run_core_tests }}
-        working-directory: pytorch-unit-tests/pytorch
-        run: ${{ github.workspace }}/pytorch-unit-tests/workflow/.github/scripts/bootstrap_tests.bat
+      - name: Archive OpenBLAS
+        if: ${{ inputs.build_openblas_msvc || inputs.build_openblas_clang }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: openblas
+          path: pytorch-unit-tests/openblas/install/*
+          retention-days: 3
       - name: Build PyTorch
         if: ${{ inputs.build_pytorch }}
         working-directory: pytorch-unit-tests/pytorch
-        run: ${{ github.workspace }}/pytorch-unit-tests/workflow/.github/scripts/build_pytorch.bat ${{ inputs.build_pytorch_openblas }}
-      - name: Run core tests
-        if: ${{ inputs.run_core_tests }}
-        working-directory: pytorch-unit-tests/pytorch/test
-        run: ${{ github.workspace }}/pytorch-unit-tests/workflow/.github/scripts/test_core.bat
-      - name: Clean up PyTorch
+        run: ${{ github.workspace }}/pytorch-unit-tests/workflow/.github/scripts/build_pytorch.bat
+      - name: Archive PyTorch
         if: ${{ inputs.build_pytorch }}
-        working-directory: pytorch-unit-tests/pytorch
-        run: ${{ github.workspace }}/pytorch-unit-tests/workflow/.github/scripts/cleanup_pytorch.bat
+        uses: actions/upload-artifact@v3
+        with:
+          name: pytorch
+          path: ${{ github.workspace }}/pytorch-unit-tests/pytorch/install/*
+          retention-days: 3
+      - name: Run tests
+        if: ${{ inputs.run_tests }}
+        working-directory: pytorch-unit-tests/pytorch/test
+        run: ${{ github.workspace }}/pytorch-unit-tests/workflow/.github/scripts/test.bat ${{ inputs.run_tests_suite }} ${{ inputs.run_tests_runs}} ${{ inputs.run_tests_filter }}
+      - name: Archive test resutls
+        if: ${{ always() && inputs.run_tests }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-reports
+          path: pytorch-unit-tests/pytorch/test/test-reports/*
+          retention-days: 7

--- a/.github/workflows/wipe-build-cache.yml
+++ b/.github/workflows/wipe-build-cache.yml
@@ -1,0 +1,16 @@
+name: Wipe build cache
+
+on: workflow_dispatch
+
+defaults:
+  run:
+    shell: cmd
+
+jobs:
+  wipe_build_cache:
+    name: Build and run tests
+    runs-on: [self-hosted, Windows, ARM64, WASM]
+    timeout-minutes: 600
+    steps:
+      - name: Wipe build cache
+        run: ${{ github.workspace }}/pytorch-unit-tests/workflow/.github/scripts/wipe_pytorch_cache.bat


### PR DESCRIPTION
After this PR will be merged, it will allow:
 - Build OpenBLAS with MSVC or Clang and build PyTorch individually producing the binary artifacts.
 - Wipe out the PyTorch build cache in a separate workflow.
 - Run the "core" test suite (when `run_tests_suite` and `run_tests_filter` parameters are empty), run individual test suites (using `run_tests_suite` parameter) and run individual tests using filter (using `run_tests_filter` parameter) producing test reports artifacts.
 - Run the individual tests repeatedly using `run_tests_runs` parameter

Limitations:
 - Some of the former workflow parameters had to be removed because of GHA 10 parameters limit.
 - One needs to know what particular tests are using BLAS/LAPACK.
 - Most of the tests are running for few milliseconds and even when run several times in a row using the `run_tests_runs` parameter, the run times are recorded individually in the test reports.