### PR TITLE
Solve github actions warnings

### DIFF
--- a/.github/workflows/daily-release.yml
+++ b/.github/workflows/daily-release.yml
@@ -12,7 +12,7 @@ jobs:
     uses: ./.github/workflows/release.yml
     with:
       blas_type: 'apl'
-      pytorch_repository: 'iremyux\pytorch'
+      pytorch_repository: 'iremyux/pytorch'
       pytorch_branch: 'apl-tests'
       wheel_name: 'torch-2.4.0a-cp311-cp311-win_arm64.whl'
       release_prefix: 'Daily Release - APL'
@@ -21,7 +21,7 @@ jobs:
     uses: ./.github/workflows/release.yml
     with:
       blas_type: 'openblas'
-      pytorch_repository: 'iremyux\pytorch'
+      pytorch_repository: 'iremyux/pytorch'
       pytorch_branch: 'apl-tests'
       wheel_name: 'torch-2.4.0a-cp311-cp311-win_arm64.whl'
       release_prefix: 'Daily Release - OpenBLAS'

--- a/.github/workflows/daily-release.yml
+++ b/.github/workflows/daily-release.yml
@@ -12,7 +12,7 @@ jobs:
     uses: ./.github/workflows/release.yml
     with:
       blas_type: 'apl'
-      pytorch_repository: 'iremyux/pytorch'
+      pytorch_repository: 'iremyux\pytorch'
       pytorch_branch: 'apl-tests'
       wheel_name: 'torch-2.4.0a-cp311-cp311-win_arm64.whl'
       release_prefix: 'Daily Release - APL'
@@ -21,7 +21,7 @@ jobs:
     uses: ./.github/workflows/release.yml
     with:
       blas_type: 'openblas'
-      pytorch_repository: 'iremyux/pytorch'
+      pytorch_repository: 'iremyux\pytorch'
       pytorch_branch: 'apl-tests'
       wheel_name: 'torch-2.4.0a-cp311-cp311-win_arm64.whl'
       release_prefix: 'Daily Release - OpenBLAS'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Create and Upload Release
         uses: softprops/action-gh-release@v2
         with:
-          files: ${{ env.WHEEL_DIR }}/*.whl
+          files: ${{ env.WHEEL_DIR }}\*
           tag_name: ${{ env.RELEASE_VERSION }}
           name: ${{ inputs.release_prefix }} - ${{ env.RELEASE_VERSION }}
           body: 'PyTorch release wheel for Windows on ARM64 (cpu-only) (RelWithDebInfo)'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ env:
   DEPENDENCIES_DIR: ${{ github.workspace }}\pytorch-job\dependencies
   SCRIPTS_DIR: ${{ github.workspace }}\pytorch-job\workflow\.github\scripts
   PYTORCH_SOURCES_DIR:  ${{ github.workspace }}\pytorch-job\src\${{ inputs.pytorch_repository }}\${{ inputs.pytorch_branch }}
-  WHEEL_DIR: ${{ github.workspace }}\pytorch-job\src\${{ inputs.pytorch_repository }}\${{ inputs.pytorch_branch }}\dist
+  WHEEL_DIR: ${{ github.workspace }}\pytorch-job\src\${{ inputs.pytorch_repository | replace('/', '\') }}\${{ inputs.pytorch_branch }}\dist
   WHEEL_NAME: ${{ inputs.wheel_name }}
   ENABLE_BUILD_WHEEL: 1
   ENABLE_APL: ${{ inputs.blas_type == 'apl' && '1' || '0' }}
@@ -107,7 +107,7 @@ jobs:
       - name: Create and Upload Release
         uses: softprops/action-gh-release@v2
         with:
-          files: ${{ env.WHEEL_DIR }}\*
+          files: ${{ env.WHEEL_DIR }}\${{ env.WHEEL_NAME }}
           tag_name: ${{ env.RELEASE_VERSION }}
           name: ${{ inputs.release_prefix }} - ${{ env.RELEASE_VERSION }}
           body: 'PyTorch release wheel for Windows on ARM64 (cpu-only) (RelWithDebInfo)'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ env:
   DEPENDENCIES_DIR: ${{ github.workspace }}\pytorch-job\dependencies
   SCRIPTS_DIR: ${{ github.workspace }}\pytorch-job\workflow\.github\scripts
   PYTORCH_SOURCES_DIR:  ${{ github.workspace }}\pytorch-job\src\${{ inputs.pytorch_repository }}\${{ inputs.pytorch_branch }}
-  WHEEL_DIR: ${{ github.workspace }}\pytorch-job\src\${{ inputs.pytorch_repository | replace('/', '\') }}\${{ inputs.pytorch_branch }}\dist
+  WHEEL_DIR: ${{ github.workspace }}\pytorch-job\src\${{ inputs.pytorch_repository }}\${{ inputs.pytorch_branch }}\dist
   WHEEL_NAME: ${{ inputs.wheel_name }}
   ENABLE_BUILD_WHEEL: 1
   ENABLE_APL: ${{ inputs.blas_type == 'apl' && '1' || '0' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,13 @@ jobs:
       - name: Build PyTorch
         run: |
           & ${{ env.SCRIPTS_DIR }}\build_pytorch.bat
+        - name: Convert Unix Slashes to Windows Slashes
+        run: |
+          $pytorch_repo = '${{ inputs.pytorch_repository }}'
+          $pytorch_repo_win = $pytorch_repo -replace '/', '\'
+          $wheel_dir = "${{ github.workspace }}\pytorch-job\src\$pytorch_repo_win\$($inputs.pytorch_branch)\dist"
+          Write-Output "Converted WHEEL_DIR: $wheel_dir"
+          echo "WHEEL_DIR=$wheel_dir" >> $env:GITHUB_ENV
       # Debugging step to list the contents of the dist directory
       - name: List dist directory contents
         run: dir ${{ env.WHEEL_DIR }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Create and Upload Release
         uses: softprops/action-gh-release@v2
         with:
-          files: ${{ env.WHEEL_DIR }}\${{ env.WHEEL_NAME }}
+          files: C:\actions-runner\_work\pytorch-ci\pytorch-ci\pytorch-job\src\iremyux\pytorch\apl-tests\dist\${{ env.WHEEL_NAME }}
           tag_name: ${{ env.RELEASE_VERSION }}
           name: ${{ inputs.release_prefix }} - ${{ env.RELEASE_VERSION }}
           body: 'PyTorch release wheel for Windows on ARM64 (cpu-only) (RelWithDebInfo)'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,12 +101,12 @@ jobs:
       - name: Build PyTorch
         run: |
           & ${{ env.SCRIPTS_DIR }}\build_pytorch.bat
-      # - name: Convert Unix Slashes to Windows Slashes
-      #   run: |
-      #     $WHEEL_DIR_WIN = $WHEEL_DIR -replace '/', '\'
-      #     $WHEEL_DIR = $WHEEL_DIR_WIN
-      #     echo $WHEEL_DIR_WIN
-      #     echo $WHEEL_DIR
+      - name: Convert Unix Slashes to Windows Slashes
+        run: |
+          $WHEEL_DIR_WIN = $WHEEL_DIR -replace '/', '\'
+          $WHEEL_DIR = $WHEEL_DIR_WIN
+          echo $WHEEL_DIR_WIN
+          echo $WHEEL_DIR
       # Debugging step to list the contents of the dist directory
       - name: List dist directory contents
         run: dir ${{ env.WHEEL_DIR }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,14 +104,13 @@ jobs:
       - name: Create Release
         id: create_release
         uses: ncipollo/release-action@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ env.RELEASE_VERSION }}
-          release_name: ${{ inputs.release_prefix }} - ${{ env.RELEASE_VERSION }}
+          tag: ${{ env.RELEASE_VERSION }}
+          name: ${{ inputs.release_prefix }} - ${{ env.RELEASE_VERSION }}
           body: 'PyTorch release wheel for Windows on ARM64 (cpu-only) (RelWithDebInfo)'
           draft: false
           prerelease: false
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload Release Asset
         id: upload-release-asset 
         uses: actions/upload-release-asset@v1.0.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,12 +70,8 @@ jobs:
     runs-on: [self-hosted, Windows, ARM64, PYTORCH]
     timeout-minutes: 800
     steps:
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
       - name: Get Release Version
-        run: echo "RELEASE_VERSION=v0.0.$(Get-Date -Format 'yyMMddHHmm')" >> $env:GITHUB_ENV
+        run: echo "RELEASE_VERSION=v0.0.$(Get-Date -Format 'yyMMddHHmm')" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
       - name: Git checkout workflow
         uses: actions/checkout@v4
         with:
@@ -107,7 +103,7 @@ jobs:
           & ${{ env.SCRIPTS_DIR }}\build_pytorch.bat
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
+        uses: actions/create-release@v1.1.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -118,7 +114,7 @@ jobs:
           prerelease: false
       - name: Upload Release Asset
         id: upload-release-asset 
-        uses: actions/upload-release-asset@v1
+        uses: actions/upload-release-asset@v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,8 +70,12 @@ jobs:
     runs-on: [self-hosted, Windows, ARM64, PYTORCH]
     timeout-minutes: 800
     steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
       - name: Get Release Version
-        run: echo "RELEASE_VERSION=v0.0.$(Get-Date -Format 'yyMMddHHmm')" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+        run: echo "RELEASE_VERSION=v0.0.$(Get-Date -Format 'yyMMddHHmm')" >> $env:GITHUB_ENV
       - name: Git checkout workflow
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,23 +101,14 @@ jobs:
       - name: Build PyTorch
         run: |
           & ${{ env.SCRIPTS_DIR }}\build_pytorch.bat
-      - name: Create Release
-        id: create_release
-        uses: ncipollo/release-action@v1
+      - name: name: Create and Upload Release
+        uses: softprops/action-gh-release@v2
         with:
-          tag: ${{ env.RELEASE_VERSION }}
-          name: ${{ inputs.release_prefix }} - ${{ env.RELEASE_VERSION }}
+          files: ${{ env.WHEEL_DIR }}\${{ env.WHEEL_NAME }}
+          tag_name: ${{ env.RELEASE_VERSION }}
+          release_name: ${{ inputs.release_prefix }} - ${{ env.RELEASE_VERSION }}
           body: 'PyTorch release wheel for Windows on ARM64 (cpu-only) (RelWithDebInfo)'
           draft: false
           prerelease: false
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Upload Release Asset
-        id: upload-release-asset 
-        uses: actions/upload-release-asset@v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ env.WHEEL_DIR }}\${{ env.WHEEL_NAME }}
-          asset_name: ${{ env.WHEEL_NAME }}
-          asset_content_type: application/zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,19 +101,17 @@ jobs:
       - name: Build PyTorch
         run: |
           & ${{ env.SCRIPTS_DIR }}\build_pytorch.bat
-      - name: Convert Unix Slashes to Windows Slashes
+      - name: Convert Unix Slashes to Windows Slashes in wheel_dir
         run: |
-          $WHEEL_DIR_WIN = $WHEEL_DIR -replace '/', '\'
-          $WHEEL_DIR = $WHEEL_DIR_WIN
-          echo $WHEEL_DIR_WIN
-          echo $WHEEL_DIR
+          $wheel_dir_win = "${{ env.WHEEL_DIR }}" -replace '/', '\'
+          echo "WHEEL_DIR_WIN=$wheel_dir_win" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
       # Debugging step to list the contents of the dist directory
       - name: List dist directory contents
         run: dir ${{ env.WHEEL_DIR }}
       - name: Create and Upload Release
         uses: softprops/action-gh-release@v2
         with:
-          files: '${{ env.WHEEL_DIR }}\${{ env.WHEEL_NAME }}'
+          files: '${{ env.WHEEL_DIR_WIN }}\${{ env.WHEEL_NAME }}'
           tag_name: ${{ env.RELEASE_VERSION }}
           name: ${{ inputs.release_prefix }} - ${{ env.RELEASE_VERSION }}
           body: 'PyTorch release wheel for Windows on ARM64 (cpu-only) (RelWithDebInfo)'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,8 @@ jobs:
           & ${{ env.SCRIPTS_DIR }}\build_pytorch.bat
       - name: Convert Unix Slashes to Windows Slashes
         run: |
-          $wheel_dir = $wheel_dir -replace '/', '\'
+          WHEEL_DIR_WIN = $WHEEL_DIR -replace '/', '\'
+          Write-Output "WHEEL_DIR=$WHEEL_DIR_WIN" >> $env:GITHUB_ENV
       # Debugging step to list the contents of the dist directory
       - name: List dist directory contents
         run: dir ${{ env.WHEEL_DIR }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ on:
       pytorch_repository:
         description: "PyTorch repository"
         required: true
-        default: "iremyux/pytorch"
+        default: "iremyux\pytorch"
         type: string
       pytorch_branch:
         description: "PyTorch branch"
@@ -107,7 +107,7 @@ jobs:
       - name: Create and Upload Release
         uses: softprops/action-gh-release@v2
         with:
-          files: ${{ env.WHEEL_DIR }}\${{ env.WHEEL_NAME }}
+          files: ${{ env.WHEEL_DIR }}\\${{ env.WHEEL_NAME }}
           tag_name: ${{ env.RELEASE_VERSION }}
           name: ${{ inputs.release_prefix }} - ${{ env.RELEASE_VERSION }}
           body: 'PyTorch release wheel for Windows on ARM64 (cpu-only) (RelWithDebInfo)'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ on:
       pytorch_repository:
         description: "PyTorch repository"
         required: true
-        default: "iremyux\\pytorch"
+        default: "iremyux/pytorch"
         type: string
       pytorch_branch:
         description: "PyTorch branch"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Build PyTorch
         run: |
           & ${{ env.SCRIPTS_DIR }}\build_pytorch.bat
-      - name: name: Create and Upload Release
+      - name: Create and Upload Release
         uses: softprops/action-gh-release@v2
         with:
           files: ${{ env.WHEEL_DIR }}\${{ env.WHEEL_NAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,11 +103,7 @@ jobs:
           & ${{ env.SCRIPTS_DIR }}\build_pytorch.bat
       - name: Convert Unix Slashes to Windows Slashes
         run: |
-          $pytorch_repo = '${{ inputs.pytorch_repository }}'
-          $pytorch_repo_win = $pytorch_repo -replace '/', '\'
-          $wheel_dir = "${{ github.workspace }}\pytorch-job\src\$pytorch_repo_win\$($inputs.pytorch_branch)\dist"
-          Write-Output "Converted WHEEL_DIR: $wheel_dir"
-          echo "WHEEL_DIR=$wheel_dir" >> $env:GITHUB_ENV
+          $wheel_dir = $wheel_dir -replace '/', '\'
       # Debugging step to list the contents of the dist directory
       - name: List dist directory contents
         run: dir ${{ env.WHEEL_DIR }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ on:
       pytorch_repository:
         description: "PyTorch repository"
         required: true
-        default: "iremyux\pytorch"
+        default: "iremyux\\pytorch"
         type: string
       pytorch_branch:
         description: "PyTorch branch"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,13 +101,10 @@ jobs:
       - name: Build PyTorch
         run: |
           & ${{ env.SCRIPTS_DIR }}\build_pytorch.bat
-      - name: Convert Unix Slashes to Windows Slashes in wheel_dir
+      - name: Convert Unix Slashes to Windows Slashes in WHEEL_DIR
         run: |
           $wheel_dir_win = "${{ env.WHEEL_DIR }}" -replace '/', '\'
           echo "WHEEL_DIR_WIN=$wheel_dir_win" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
-      # Debugging step to list the contents of the dist directory
-      - name: List dist directory contents
-        run: dir ${{ env.WHEEL_DIR }}
       - name: Create and Upload Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Create and Upload Release
         uses: softprops/action-gh-release@v2
         with:
-          files: ${{ env.WHEEL_DIR }}\\${{ env.WHEEL_NAME }}
+          files: ${{ env.WHEEL_DIR }}/*.whl
           tag_name: ${{ env.RELEASE_VERSION }}
           name: ${{ inputs.release_prefix }} - ${{ env.RELEASE_VERSION }}
           body: 'PyTorch release wheel for Windows on ARM64 (cpu-only) (RelWithDebInfo)'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
           & ${{ env.SCRIPTS_DIR }}\build_pytorch.bat
       - name: Convert Unix Slashes to Windows Slashes in WHEEL_DIR
         run: |
-          $wheel_dir_win = "${{ env.WHEEL_DIR }}" -replace '\', '/'
+          $wheel_dir_win = "${{ env.WHEEL_DIR }}" -replace '\\', '/'
           echo "WHEEL_DIR_WIN=$wheel_dir_win" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
       - name: Create and Upload Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
           & ${{ env.SCRIPTS_DIR }}\build_pytorch.bat
       - name: Convert Unix Slashes to Windows Slashes
         run: |
-          WHEEL_DIR_WIN = $WHEEL_DIR -replace '/', '\'
+          $WHEEL_DIR_WIN = $WHEEL_DIR -replace '/', '\'
           Write-Output "WHEEL_DIR=$WHEEL_DIR_WIN" >> $env:GITHUB_ENV
       # Debugging step to list the contents of the dist directory
       - name: List dist directory contents

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,12 +103,12 @@ jobs:
           & ${{ env.SCRIPTS_DIR }}\build_pytorch.bat
       - name: Convert Unix Slashes to Windows Slashes in WHEEL_DIR
         run: |
-          $wheel_dir_win = "${{ env.WHEEL_DIR }}" -replace '/', '\'
+          $wheel_dir_win = "${{ env.WHEEL_DIR }}" -replace '\', '/'
           echo "WHEEL_DIR_WIN=$wheel_dir_win" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
       - name: Create and Upload Release
         uses: softprops/action-gh-release@v2
         with:
-          files: '${{ env.WHEEL_DIR_WIN }}\${{ env.WHEEL_NAME }}'
+          files: '${{ env.WHEEL_DIR_WIN }}/${{ env.WHEEL_NAME }}'
           tag_name: ${{ env.RELEASE_VERSION }}
           name: ${{ inputs.release_prefix }} - ${{ env.RELEASE_VERSION }}
           body: 'PyTorch release wheel for Windows on ARM64 (cpu-only) (RelWithDebInfo)'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Build PyTorch
         run: |
           & ${{ env.SCRIPTS_DIR }}\build_pytorch.bat
-        - name: Convert Unix Slashes to Windows Slashes
+      - name: Convert Unix Slashes to Windows Slashes
         run: |
           $pytorch_repo = '${{ inputs.pytorch_repository }}'
           $pytorch_repo_win = $pytorch_repo -replace '/', '\'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
           & ${{ env.SCRIPTS_DIR }}\build_pytorch.bat
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1.1.4
+        uses: ncipollo/release-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,12 +101,15 @@ jobs:
       - name: Build PyTorch
         run: |
           & ${{ env.SCRIPTS_DIR }}\build_pytorch.bat
+      # Debugging step to list the contents of the dist directory
+      - name: List dist directory contents
+        run: dir ${{ env.WHEEL_DIR }}
       - name: Create and Upload Release
         uses: softprops/action-gh-release@v2
         with:
           files: ${{ env.WHEEL_DIR }}\${{ env.WHEEL_NAME }}
           tag_name: ${{ env.RELEASE_VERSION }}
-          release_name: ${{ inputs.release_prefix }} - ${{ env.RELEASE_VERSION }}
+          name: ${{ inputs.release_prefix }} - ${{ env.RELEASE_VERSION }}
           body: 'PyTorch release wheel for Windows on ARM64 (cpu-only) (RelWithDebInfo)'
           draft: false
           prerelease: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,17 +101,19 @@ jobs:
       - name: Build PyTorch
         run: |
           & ${{ env.SCRIPTS_DIR }}\build_pytorch.bat
-      - name: Convert Unix Slashes to Windows Slashes
-        run: |
-          $WHEEL_DIR_WIN = $WHEEL_DIR -replace '/', '\'
-          Write-Output "WHEEL_DIR=$WHEEL_DIR_WIN" >> $env:GITHUB_ENV
+      # - name: Convert Unix Slashes to Windows Slashes
+      #   run: |
+      #     $WHEEL_DIR_WIN = $WHEEL_DIR -replace '/', '\'
+      #     $WHEEL_DIR = $WHEEL_DIR_WIN
+      #     echo $WHEEL_DIR_WIN
+      #     echo $WHEEL_DIR
       # Debugging step to list the contents of the dist directory
       - name: List dist directory contents
         run: dir ${{ env.WHEEL_DIR }}
       - name: Create and Upload Release
         uses: softprops/action-gh-release@v2
         with:
-          files: C:\actions-runner\_work\pytorch-ci\pytorch-ci\pytorch-job\src\iremyux\pytorch\apl-tests\dist\${{ env.WHEEL_NAME }}
+          files: '${{ env.WHEEL_DIR }}\${{ env.WHEEL_NAME }}'
           tag_name: ${{ env.RELEASE_VERSION }}
           name: ${{ inputs.release_prefix }} - ${{ env.RELEASE_VERSION }}
           body: 'PyTorch release wheel for Windows on ARM64 (cpu-only) (RelWithDebInfo)'

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -116,9 +116,7 @@ jobs:
           & ${{ env.SCRIPTS_DIR }}\build_pytorch.bat
       - name: Archive PyTorch
         if: ${{ inputs.is_archive_pytorch }}
-        runs:
-          using: 'node20'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pytorch
           path: ${{ env.PYTORCH_SOURCES_DIR }}/build/lib.win-arm64-cpython-311/torch/*

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -116,6 +116,8 @@ jobs:
           & ${{ env.SCRIPTS_DIR }}\build_pytorch.bat
       - name: Archive PyTorch
         if: ${{ inputs.is_archive_pytorch }}
+        runs:
+          using: 'node20'
         uses: actions/upload-artifact@v3
         with:
           name: pytorch
@@ -131,7 +133,7 @@ jobs:
           & ${{ env.SCRIPTS_DIR }}\test.bat ${{ inputs.run_tests_runs}} ${{ inputs.run_tests_suite }} ${{ inputs.run_tests_filter }}
       - name: Archive test results
         if: ${{ always() && inputs.is_run_tests }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-reports
           path: ${{ env.JOB_DIR }}/pytorch/test/test-reports/*


### PR DESCRIPTION
- Update upload-artifact calls to v4
- Replace deprecated create release and upload release actions with maintained action